### PR TITLE
Improve parsing of float values returned by API

### DIFF
--- a/custom_components/eta/sensor.py
+++ b/custom_components/eta/sensor.py
@@ -78,10 +78,16 @@ class EtaSensor(SensorEntity):
         """
         _LOGGER.warning("ETA Integration - init sensor")
 
-        self._attr_state_class = state_class
         self._attr_device_class = self.determine_device_class(unit)
+
         if unit == "":
             unit = None
+
+        if self._attr_device_class == SensorDeviceClass.ENERGY:
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        else:
+            self._attr_state_class = state_class
+
         self._attr_native_unit_of_measurement = unit
         self._attr_native_value = float
         id = name.lower().replace(" ", "_")

--- a/custom_components/eta/sensor.py
+++ b/custom_components/eta/sensor.py
@@ -107,10 +107,20 @@ class EtaSensor(SensorEntity):
 
     @staticmethod
     def determine_device_class(unit):
-        # TODO: Expand this function with more useable units
         unit_dict_eta = {
             "°C": SensorDeviceClass.TEMPERATURE,
             "W": SensorDeviceClass.POWER,
+            "A": SensorDeviceClass.CURRENT,
+            "Hz": SensorDeviceClass.FREQUENCY,
+            "Pa": SensorDeviceClass.PRESSURE,
+            "V": SensorDeviceClass.VOLTAGE,
+            "W/m²": SensorDeviceClass.IRRADIANCE,
+            "bar": SensorDeviceClass.PRESSURE,
+            "kW": SensorDeviceClass.POWER,
+            "kWh": SensorDeviceClass.ENERGY,
+            "kg": SensorDeviceClass.WEIGHT,
+            "mV": SensorDeviceClass.VOLTAGE,
+            "s": SensorDeviceClass.DURATION,
         }
 
         if unit in unit_dict_eta:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,7 +66,7 @@ async def test_get_data(monkeypatch):
     eta = EtaAPI("session", "host", "port")
 
     value, unit = await eta.get_data("blub")
-    assert value == "6539"
+    assert value == 6539
     assert unit == "kg"
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,6 +47,7 @@ def throw_error_test_url_fixture():
 # we want the config flow validation to succeed during the test.
 
 
+@pytest.mark.asyncio
 async def test_successful_config_flow(hass, bypass_test_url_fixture):
     """Test a successful config flow."""
     # Initialize a config flow
@@ -84,6 +85,7 @@ async def test_successful_config_flow(hass, bypass_test_url_fixture):
 
 
 # In this case, we want to simulate a failure during the config flow.
+@pytest.mark.asyncio
 async def test_failed_config_flow(hass, throw_error_test_url_fixture):
     """Test a failed config flow due to credential validation failure."""
     result = await hass.config_entries.flow.async_init(
@@ -101,6 +103,7 @@ async def test_failed_config_flow(hass, throw_error_test_url_fixture):
     assert result["errors"] == {"base": "url_broken"}
 
 
+@pytest.mark.asyncio
 async def test_options_flow_remove_sensor(bypass_test_url_fixture, hass):
     """Test config flow options."""
     m_instance = AsyncMock()
@@ -137,6 +140,7 @@ async def test_options_flow_remove_sensor(bypass_test_url_fixture, hass):
 
 
 
+@pytest.mark.asyncio
 async def test_options_flow_add_repo(bypass_test_url_fixture, hass):
     """Test config flow options."""
     m_instance = AsyncMock()


### PR DESCRIPTION
This change improves the parsing of float values returned by the API. This is done by using the numerical value, scale factor and number of decimal places specified in the API response instead of trying to cast the string representation directly to a float. This is only done for values that can be identified as floats by their unit.

Casting the string representation directly to float caused problems when the string contained `,` instaed `.` for decimals points.

I have also mapped the units returned by the API to the corresponding `SensorDeviceClass` units in Homeassistant.

This PR should resolve issues #1 and #2  