### PR TITLE
Fix async_forward_entry_setups for newer HA versions

### DIFF
--- a/custom_components/eta/__init__.py
+++ b/custom_components/eta/__init__.py
@@ -19,7 +19,7 @@ async def async_setup_entry(
     hass.data[DOMAIN][entry.entry_id] = hass_data
 
     # Forward the setup to the sensor platform.
-    await hass.config_entries.async_forward_entry_setups(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     return True
 
 


### PR DESCRIPTION
async_forward_entry_setups expects a list of strings instead of a a single string.